### PR TITLE
add RTOS bootable kernel assembly language code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 commit_message.txt
 kernel.img
 .DS_Store
-kernel7.img
-*.o
-*.elf
-*.bin
+bootable_kernel/kernel7.img
+bootable_kernel/*.o
+bootable_kernel/*.elf
+bootable_kernel/*.bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 commit_message.txt
 kernel.img
 .DS_Store
-
+kernel7.img
+*.o
+*.elf
+*.bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 commit_message.txt
 kernel.img
+.DS_Store
+

--- a/bootable_kernel/LICENSE.txt
+++ b/bootable_kernel/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Joe Loughry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/bootable_kernel/Makefile
+++ b/bootable_kernel/Makefile
@@ -1,0 +1,24 @@
+# This makes a bootable kernel for a Raspberry Pi 3 Model B.
+
+bootable_kernel: kernel7.img
+
+ARCH = arm-none-eabi
+
+vectors.o: vectors.s
+	$(ARCH)-as vectors.s -o vectors.o
+
+rtos.o: rtos.s
+	$(ARCH)-as rtos.s -o rtos.o
+
+rtos.elf: rtos.o vectors.o memmap
+	$(ARCH)-ld vectors.o rtos.o -T memmap -o rtos.elf
+
+rtos.bin: rtos.elf
+	$(ARCH)-objcopy rtos.elf -O binary rtos.bin
+
+kernel7.img: rtos.bin
+	cp rtos.bin kernel7.img
+
+clean:
+	rm -fv *.o *.bin *.elf *.img
+

--- a/bootable_kernel/README.md
+++ b/bootable_kernel/README.md
@@ -1,0 +1,53 @@
+# RTOS
+
+This is the beginnings of a new RTOS for Raspberry Pi B hardware, *e.g.*,
+the Raspberry Pi 3 Model B &mdash; the current version.
+
+It is a bootable OS kernel in 160 bytes on bare metal. It boots much faster
+than Linux.
+
+It has been tested on a Raspberry Pi 3 Model B; it should run on a Compute
+Module 3 or 3 lite, or a Pi Zero, but has not been tested there.
+
+The project was started by Ryan Loughry, a student at Grandview High School
+in Aurora, Colorado. There were two parallel implementations of the new
+RTOS; this is mine.
+
+For more information, contact [Joe Loughry](mailto:joe.loughry@gmail.com).
+
+## How to Build:
+
+`make`
+
+You'll need an assembler for the ARM architecture; install the [GNU Embedded
+Toolchain for
+ARM](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads);
+there are Windows, Linux, and Mac OS X versions. As long as you can run the
+assembler as `arm-none-eabi-as` then you're good.
+
+Once you've got the actual `kernel.img` file, copy it to the root of a
+Linux-formatted micro-SD card that already has the Raspbian OS on it, or
+renamed `recovery.img` on the root of a FAT-formatted micro-SD card. Either
+way, it'll boot when the Raspberry Pi is next powered on.
+
+The only way to know this kernel is running is to watch an LED conneced to
+GPIO pin BCM 16 on J8 through a small resistor to ground. The LED will
+flash at a rate of 1 Hz.
+
+## Technical Notes:
+
+The base address for the Raspberry Pi 3b is 0x3F000000, changed from
+0x20000000 on the original Raspberry Pi.
+
+When referring to GPIO pins, use the "BCM" pin numbering scheme, not the
+other various ways of numbering Raspberry Pi GPIO pins on the J8 header.
+
+For testing, connect an LED through a resistor of approximately 100 to 400
+ohms between the GPIO pin and a ground pin (if the LED doesn't light up,
+turn it around).
+
+There's no real scheduler yet, just round robin, and only one task; it uses
+a busy-wait for timing. But the hard part was getting anything at all to boot
+on the Raspberry Pi 3 hardware; after that, the rest (interrupts, timing,
+priority scheduler, I/O) is, in comparison, easy.
+

--- a/bootable_kernel/memmap
+++ b/bootable_kernel/memmap
@@ -1,0 +1,11 @@
+
+MEMORY
+{
+    ram : ORIGIN = 0x8000, LENGTH = 0x10000
+}
+
+SECTIONS
+{
+    .text : { *(.text*) } > ram
+    .bss : { *(.bss*) } > ram
+}

--- a/bootable_kernel/rtos.s
+++ b/bootable_kernel/rtos.s
@@ -1,0 +1,90 @@
+    @ rtos.s
+    @ Version 20170423.1555
+    @ Compile it this way:
+    @
+    @ arm-none-eabi-as vectors.s -o vectors.o
+    @ arm-none-eabi-as rtos.s -o rtos.o
+    @ arm-none-eabi-ld vectors.o rtos.o -T memmap -o rtos.elf
+    @ arm-none-eabi-objcopy rtos.elf -O binary rtos.bin
+    @
+    @ And then rename rtos.bin to kernel7.img on the Raspberry Pi's
+    @ micro-SD card (or recovery7.img for use on a FAT-formatted SD card)
+    @
+    @ Target hardware: Raspberry Pi Model 3b with an LED on BCM 16
+    @ (pin 36 of the J8 header) to ground through a resistor. For
+    @ more information see the Makefile at
+    @ https://github.com/dwelch67/raspberrypi/blob/master/blinker01/
+    
+    .cpu arm7tdmi
+
+    .eabi_attribute 20, 1   @ FP_denormal
+    .eabi_attribute 21, 1   @ FP_exceptions
+    .eabi_attribute 23, 3   @ FP_number_model 3
+    .eabi_attribute 24, 1   @ align8_needed
+    .eabi_attribute 25, 1   @ align8_preserved
+    .eabi_attribute 26, 1   @ short enums
+    .eabi_attribute 30, 2   @ optimisation goals 2
+    .eabi_attribute 34, 0   @ no unaligned access
+    .eabi_attribute 18, 4   @ PCS_wchar_t 4
+    .text
+    .align 2
+    .global notmain
+    .syntax unified
+    .arm
+    .fpu softvfp
+    .type notmain, %function
+notmain:
+    @ Analogous to main() in C but with less overhead.
+    push    {r4, r5, r6, r7, r8, lr}
+    ldr     r0, .base_addr
+    bl      GET32   @ external function
+    bic     r1, r0, #1835008    @ 7<<18
+    orr     r1, r1, #262144     @ 1<<18
+    ldr     r0, .base_addr
+    bl      PUT32   @ external function
+    mov     r5, #65536          @ 1<<16
+    ldr     r7, .gpio_set
+    ldr     r6, .gpio_clear
+
+.infinite_loop:    @ This is the beginning of an infinite loop.
+
+    @ Tell the LED to turn on.
+    mov     r1, r5
+    mov     r0, r7
+    bl      PUT32   @ control the GPIO
+
+    @ This is a for loop; call dummy() about a million times.
+    mov     r4, #0  @ This is the counter.
+.delay1:
+    mov     r0, r4          @ dummy() takes r0
+    add     r4, r4, #1      @ This is the increment part.
+    bl      dummy   @ dummy() is an external function.
+    cmp     r4, #1048576    @ This is the compare part.
+    bne     .delay1
+
+    @ Tell the LED to turn off.
+    mov     r1, r5
+    mov     r0, r6
+    bl      PUT32   @ control the GPIO
+
+    @ This is a for loop; call dummy() about a million times.
+    mov     r4, #0  @ This is the counter.
+.delay2:
+    mov     r0, r4          @ dummy() takes r0
+    add     r4, r4, #1      @ This is the increment part.
+    bl      dummy
+    cmp     r4, #1048576    @ This is the compare part.
+    bne     .delay2
+
+    b       .infinite_loop     @ around and around we go
+
+.data_area:
+    .align   2
+.base_addr:
+    .word    1059061764
+.gpio_set:
+    .word    1059061788
+.gpio_clear:
+    .word    1059061800
+    .size    notmain, .-notmain
+

--- a/bootable_kernel/vectors.s
+++ b/bootable_kernel/vectors.s
@@ -1,0 +1,39 @@
+
+;@ ------------------------------------------------------------------
+;@ ------------------------------------------------------------------
+
+.globl _start
+_start:
+    mov sp,#0x8000
+    bl notmain
+hang: b hang
+
+.globl PUT32
+PUT32:
+    str r1,[r0]
+    bx lr
+
+.globl GET32
+GET32:
+    ldr r0,[r0]
+    bx lr
+
+.globl dummy
+dummy:
+    bx lr
+
+;@-------------------------------------------------------------------------
+;@-------------------------------------------------------------------------
+
+
+;@-------------------------------------------------------------------------
+;@
+;@ Copyright (c) 2012 David Welch dwelch@dwelch.com
+;@
+;@ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+;@
+;@ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+;@
+;@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+;@
+;@-------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds a new directory (bootable_kernel) containing the assembly language source code for a bootable kernel on Raspberry Pi 3 Model B hardware in 160 bytes of binary. Everything is documented in the README file (bootable_kernel/README.md).